### PR TITLE
Set deployment target to iOS 8.0

### DIFF
--- a/ObjCLucene.xcodeproj/project.pbxproj
+++ b/ObjCLucene.xcodeproj/project.pbxproj
@@ -13074,7 +13074,7 @@
 					"$(SRCROOT)/vendor/j2objc/include",
 					"$(SRCROOT)/include",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -13095,7 +13095,7 @@
 					"$(SRCROOT)/vendor/j2objc/include",
 					"$(SRCROOT)/include",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Hi @lukhnos,

As I did not find any reason to keep the iOS deployment target to **8.4** I set it down to **8.0**.

So far iOS 8 is still very common on the mobile devices out there.
It would be good to support them, especially if it does not impact (afaik) the performance of `objclucene`.

Best;
